### PR TITLE
Raspberry Pi Pico 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Raspberry Pi Pico Docker SDK
 
-A lightweight SDK environment for Raspberry Pi Pico in a Docker container.
+A SDK environment for Raspberry Pi Pico 1 and 2 in a Docker container.
 
 ## Pulling the Image from Docker Hub and Running
 
@@ -50,8 +50,8 @@ Follow [this](https://code.visualstudio.com/docs/devcontainers/tutorial#_prerequ
 
 #### Using the Dev Container for Pico IDE
 
-- Clone [pico-dev-container](https://github.com/lukstep/pico-dev-container/tree/main) repository.
-- Open `pico-dev-container` folder in Visual Studio Code.
+- Clone [pico-template-project](https://github.com/lukstep/pico-template-project) repository.
+- Open `pico-template-project` folder in Visual Studio Code.
 - In VSCode, click the button in the bottom left corner of VSCode and select: Reopen in Container...
 ![image-1](https://github.com/lukstep/raspberry-pi-pico-docker-sdk/assets/20487002/f1f06bca-cb0b-4c2d-bf4c-611ef004e70a)
 - Build the project.
@@ -59,6 +59,9 @@ Follow [this](https://code.visualstudio.com/docs/devcontainers/tutorial#_prerequ
 ![image-1](https://github.com/lukstep/raspberry-pi-pico-docker-sdk/assets/20487002/ed367c06-aa9f-440a-9ca2-ddfbd7bdd266)
 
 ## Pico Memory Flashing and Debugging via Pico Probe and OpenOCD
+
+> [!WARNING]  
+> OpenOCD not support RP2350 (Pico 2). Currently this part is only valid for RP2040 boards (Pico 1).
 
 To work efficiently on the project, we need the ability to upload firmware to the microcontroller, debug, and communicate through the serial port. The Raspberry Pi Pico board itself allows for software uploads, but this process is not very convenient or efficient for larger projects. The Pico Probe extends the capabilities of the Raspberry Pi Pico board to include fast firmware uploads to the microcontroller's memory, debugging via Serial Wire Debug (SWD), and it also serves as a USB UART converter.
 
@@ -147,5 +150,7 @@ Refer [here](docs/vscode_manual_setup.md) for step-by-step instruction
 ## References
 
 [Raspberry Pi Debug Probe](https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html)
+
+[Raspberry Pi Pico C/C++ SDK](https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf)
 
 [OpenOCD project page](https://openocd.org)

--- a/install_gcc.sh
+++ b/install_gcc.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+RET_VALUE=$?
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+apt-get update -y && \
+apt-get upgrade -y && \
+apt-get install -y autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+
+
+if [ $RET_VALUE != 0 ]; then
+    echo "${RED}Instalation failed!${NC}"
+    exit 1
+fi
+
+mkdir -p /opt/riscv/gcc14-rp2350-no-zcmp
+
+chown -R "$(whoami)" /opt/riscv/gcc14-rp2350-no-zcmp
+
+git clone --depth 1 https://github.com/riscv/riscv-gnu-toolchain /home/riscv-gnu-toolchain
+
+if [ $RET_VALUE != 0 ]; then
+    echo "${RED}Cloning RISC-V repo failed!${NC}"
+    exit 1
+fi
+
+cd /home/riscv-gnu-toolchain || exit
+
+git clone --depth 1 https://github.com/gcc-mirror/gcc gcc-14 -b releases/gcc-14
+
+if [ $RET_VALUE != 0 ]; then
+    echo "${RED}Cloning GCC repo failed!${NC}"
+    exit 1
+fi
+
+./configure --prefix=/opt/riscv/gcc14-rp2350-no-zcmp \
+    --with-arch=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb --with-abi=ilp32 \
+    --with-multilib-generator="rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb-ilp32--;rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb-ilp32--" \
+    --with-gcc-src=`pwd`/gcc-14
+
+if [ $RET_VALUE != 0 ]; then
+    echo "${RED}Configure failed!${NC}"
+    exit 1
+fi
+
+make -j$(nproc)
+
+cd /home || exit
+
+rm -rf /home/riscv-gnu-toolchain

--- a/test_poject/CMakeLists.txt
+++ b/test_poject/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
-include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
-
+include($ENV{PICO_SDK_PATH}/pico_sdk_init.cmake)
 project(sample C CXX ASM)
-
-set(CMAKE_C_COMPILER /usr/bin/arm-none-eabi-gcc CACHE PATH "" FORCE)
-set(CMAKE_CXX_COMPILER /usr/bin/arm-none-eabi-g++ CACHE PATH "" FORCE)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)

--- a/test_sdk.sh
+++ b/test_sdk.sh
@@ -1,15 +1,53 @@
+#! /usr/bin/env bash
+
+RED="\e[31m"
+GREEN="\e[32m"
+NC="\e[0m"
+STATUS=0
+
 if [[ -z $1 ]]; then
     echo "Please provide an SDK image you want to test"
 fi
 
-docker run -d -it --name pico-sdk --mount type=bind,source=${PWD}/test_poject,target=/home/dev $1
-docker exec pico-sdk /bin/sh -c "cd /home/dev && mkdir build && cd build && cmake .. && make -j4"
-docker exec pico-sdk /bin/sh -c "picotool"
+declare -a boards=("pico" "pico_w" "pico2" "pico2_riscv")
+
+
+docker run -d -it --name pico-sdk --mount type=bind,source="${PWD}"/test_poject,target=/home/dev "$1"
+
+for board in "${boards[@]}"
+do
+    echo "---- $board build test ----"
+    docker exec pico-sdk /bin/bash -c "rm -rf /home/dev/build"
+    if [[ $board = pico2_riscv ]] ; then
+        docker exec -i pico-sdk /bin/bash -c "cd /home/dev && mkdir build && cd build && cmake .. -DPICO_BOARD=pico2 -DPICO_PLATFORM=rp2350-riscv && make -j4"
+    else
+        docker exec -i pico-sdk /bin/bash -c "cd /home/dev && mkdir build && cd build && cmake .. -DPICO_BOARD=${board} && make -j4"
+    fi
+    if [ $? != 0 ]; then
+        echo -e "${RED}----- Test failed -----${NC}"
+        STATUS=1
+        break
+    fi
+    echo "${GREEN}----- Test passed -----${NC}"
+done
+
 docker container kill pico-sdk
 docker container rm pico-sdk
 
-docker run -d -it --name pico-sdk --mount type=bind,source=${PWD}/freertos_test_project,target=/home/dev $1
-docker exec pico-sdk /bin/sh -c "cd /home/dev && mkdir build && cd build && cmake .. && make -j4"
-docker exec pico-sdk /bin/sh -c "picotool"
-docker container kill pico-sdk
-docker container rm pico-sdk
+exit ${STATUS}
+
+# for board in "${boards[@]}"
+# do
+#     echo "FreeRTOS $board build test"
+#     docker run -d -it --name pico-sdk --mount type=bind,source=${PWD}/freertos_test_project,target=/home/dev $1
+#     if [[ $board -eq "pico2_riscv" ]] ; then
+#         docker exec pico-sdk /bin/bash -c "cd /home/dev && mkdir build && cd build && cmake .. -DPICO_BOARD=pico2 -DPICO_PLATFORM=rp2350-riscv && make -j4"
+#     else
+#         docker exec pico-sdk /bin/bash -c "cd /home/dev && mkdir build && cd build && cmake .. -DPICO_BOARD=${board} && make -j4 && cd .. && rm -rf build"
+#     fi
+#     docker exec pico-sdk /bin/bash -c "rm -rf /home/dev/build"
+#     docker container kill pico-sdk
+#     docker container rm pico-sdk
+#     rm -rf ./test_poject/build/
+# done
+


### PR DESCRIPTION
Changes:
- Support for Raspberry Pi Pico 2, ARM, and RISC-V cores.
- Switching to Ubuntu.
- Build tests for all official boards.

Base image: Ubuntu 24.10
Pico-sdk: 2.0.0
Picotool: 2.0.0
FreeRTOS: currently not supported 